### PR TITLE
Node: Simplify the interface to add attributes

### DIFF
--- a/src/dts.rs
+++ b/src/dts.rs
@@ -9,7 +9,6 @@ mod tests {
     use crate::element::Element;
     use crate::node::Node;
     use crate::tree::Tree;
-    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_dts_0() {
@@ -18,16 +17,13 @@ mod tests {
         println!("{dts_0_text}");
         // Build the same device tree with API and compare
         let mut root = Node::new("");
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
+        root.add_attr(Attribute::new(
             "compatible",
             vec![String::from("linux,dummy-virt")],
-        ))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#address-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "interrupt-parent",
-            1u32,
-        ))));
+        ));
+        root.add_attr(Attribute::new("#address-cells", 2u32));
+        root.add_attr(Attribute::new("#size-cells", 2u32));
+        root.add_attr(Attribute::new("interrupt-parent", 1u32));
         let dt = Tree::new(root);
         let dts = dt.to_dts(0);
         assert_eq!(dts_0_text, dts);
@@ -40,15 +36,12 @@ mod tests {
         println!("{dts_1_text}");
         // Build the same device tree with API and compare
         let mut root = Node::new("");
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#address-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 2u32))));
+        root.add_attr(Attribute::new("#address-cells", 2u32));
+        root.add_attr(Attribute::new("#size-cells", 2u32));
         let mut memory = Node::new("memory");
-        memory.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "device_type",
-            String::from("memory"),
-        ))));
+        memory.add_attr(Attribute::new("device_type", String::from("memory")));
         let reg = vec![0u32, 0x40000000u32, 1u32, 0u32];
-        memory.add_attr(Arc::new(Mutex::new(Attribute::new("reg", reg))));
+        memory.add_attr(Attribute::new("reg", reg));
         root.add_sub_node(memory);
         let dt = Tree::new(root);
         let dts = dt.to_dts(0);
@@ -63,56 +56,41 @@ mod tests {
 
         // Build the same device tree with API and compare
         let mut root = Node::new("");
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
+        root.add_attr(Attribute::new(
             "compatible",
             vec![String::from("linux,dummy-virt")],
-        ))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#address-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "interrupt-parent",
-            1u32,
-        ))));
+        ));
+        root.add_attr(Attribute::new("#address-cells", 2u32));
+        root.add_attr(Attribute::new("#size-cells", 2u32));
+        root.add_attr(Attribute::new("interrupt-parent", 1u32));
 
         // CPUs
         let mut cpus = Node::new("cpus");
-        cpus.add_attr(Arc::new(Mutex::new(Attribute::new("#address-cells", 2u32))));
-        cpus.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 0u32))));
+        cpus.add_attr(Attribute::new("#address-cells", 2u32));
+        cpus.add_attr(Attribute::new("#size-cells", 0u32));
 
         // CPU@0
         let mut cpu0 = Node::new("cpu@0");
-        cpu0.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "device_type",
-            String::from("cpu"),
-        ))));
-        cpu0.add_attr(Arc::new(Mutex::new(Attribute::new(
+        cpu0.add_attr(Attribute::new("device_type", String::from("cpu")));
+        cpu0.add_attr(Attribute::new(
             "compatible",
             vec![String::from("arm,arm-v8")],
-        ))));
-        cpu0.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "enable-method",
-            String::from("psci"),
-        ))));
+        ));
+        cpu0.add_attr(Attribute::new("enable-method", String::from("psci")));
         let reg = vec![0u32, 0u32];
-        cpu0.add_attr(Arc::new(Mutex::new(Attribute::new("reg", reg))));
+        cpu0.add_attr(Attribute::new("reg", reg));
         cpus.add_sub_node(cpu0);
 
         // CPU@1
         let mut cpu1 = Node::new("cpu@1");
-        cpu1.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "device_type",
-            String::from("cpu"),
-        ))));
-        cpu1.add_attr(Arc::new(Mutex::new(Attribute::new(
+        cpu1.add_attr(Attribute::new("device_type", String::from("cpu")));
+        cpu1.add_attr(Attribute::new(
             "compatible",
             vec![String::from("arm,arm-v8")],
-        ))));
-        cpu1.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "enable-method",
-            String::from("psci"),
-        ))));
+        ));
+        cpu1.add_attr(Attribute::new("enable-method", String::from("psci")));
         let reg = vec![0u32, 1u32];
-        cpu1.add_attr(Arc::new(Mutex::new(Attribute::new("reg", reg))));
+        cpu1.add_attr(Attribute::new("reg", reg));
         cpus.add_sub_node(cpu1);
 
         root.add_sub_node(cpus);
@@ -131,29 +109,23 @@ mod tests {
 
         // Build the same device tree with API and compare
         let mut root = Node::new("");
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
+        root.add_attr(Attribute::new(
             "compatible",
             vec![String::from("linux,dummy-virt")],
-        ))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#address-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 2u32))));
-        root.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "interrupt-parent",
-            1u32,
-        ))));
+        ));
+        root.add_attr(Attribute::new("#address-cells", 2u32));
+        root.add_attr(Attribute::new("#size-cells", 2u32));
+        root.add_attr(Attribute::new("interrupt-parent", 1u32));
 
         // PCI
         let mut pci = Node::new("pci");
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
+        pci.add_attr(Attribute::new(
             "compatible",
             vec![String::from("pci-host-ecam-generic")],
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "device_type",
-            String::from("pci"),
-        ))));
+        ));
+        pci.add_attr(Attribute::new("device_type", String::from("pci")));
 
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
+        pci.add_attr(Attribute::new(
             "ranges",
             vec![
                 0x2000000u32,
@@ -171,31 +143,19 @@ mod tests {
                 0xfeu32,
                 0xbfff0000u32,
             ],
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "bus-range",
-            vec![0u32, 0u32],
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "#address-cells",
-            0x3u32,
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new("#size-cells", 0x2u32))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
+        ));
+        pci.add_attr(Attribute::new("bus-range", vec![0u32, 0u32]));
+        pci.add_attr(Attribute::new("#address-cells", 0x3u32));
+        pci.add_attr(Attribute::new("#size-cells", 0x2u32));
+        pci.add_attr(Attribute::new(
             "reg",
             vec![0u32, 0x30000000u32, 0x0u32, 0x10000000u32],
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "#interrupt-cells",
-            1u32,
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new("interrupt-map", None))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new(
-            "interrupt-map-mask",
-            None,
-        ))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new("dma-coherent", None))));
-        pci.add_attr(Arc::new(Mutex::new(Attribute::new("msi-parent", 0x2u32))));
+        ));
+        pci.add_attr(Attribute::new("#interrupt-cells", 1u32));
+        pci.add_attr(Attribute::new("interrupt-map", None));
+        pci.add_attr(Attribute::new("interrupt-map-mask", None));
+        pci.add_attr(Attribute::new("dma-coherent", None));
+        pci.add_attr(Attribute::new("msi-parent", 0x2u32));
 
         root.add_sub_node(pci);
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,12 +3,12 @@
 
 use crate::element::Element;
 use crate::utils::Utils;
-use std::sync::{Arc, Mutex};
+use std::rc::Rc;
 
 pub struct Node {
     name: String,
-    attributes: Vec<Arc<Mutex<dyn Element>>>,
-    sub_nodes: Vec<Arc<Mutex<Node>>>,
+    attributes: Vec<Rc<dyn Element>>,
+    sub_nodes: Vec<Rc<Node>>,
 }
 
 impl Node {
@@ -20,12 +20,12 @@ impl Node {
         }
     }
 
-    pub fn add_attr(&mut self, attr: Arc<Mutex<dyn Element>>) {
-        self.attributes.push(attr);
+    pub fn add_attr(&mut self, attr: impl Element + 'static) {
+        self.attributes.push(Rc::new(attr));
     }
 
     pub fn add_sub_node(&mut self, sub_node: Node) {
-        self.sub_nodes.push(Arc::new(Mutex::new(sub_node)));
+        self.sub_nodes.push(Rc::new(sub_node));
     }
 }
 
@@ -39,13 +39,13 @@ impl Element for Node {
         }
         s.push_str("{\n");
         for attr in self.attributes.iter() {
-            s.push_str(&attr.lock().unwrap().to_dts(indent_level + 1));
+            s.push_str(&attr.to_dts(indent_level + 1));
             s.push_str("\n");
         }
 
         for sub_node in self.sub_nodes.iter() {
             s.push_str("\n");
-            s.push_str(&sub_node.lock().unwrap().to_dts(indent_level + 1));
+            s.push_str(&sub_node.to_dts(indent_level + 1));
             s.push_str("\n");
         }
         s.push_str(&format!("{indents}}};"));
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_simple_node() {
-        let attr = Arc::new(Mutex::new(Attribute::new("attr1", 42u32)));
+        let attr = Attribute::new("attr1", 42u32);
         let mut node = Node::new("node");
         node.add_attr(attr);
         println!("Node: {}", node.to_dts(0));
@@ -68,12 +68,12 @@ mod tests {
 
     #[test]
     fn test_sub_node() {
-        let attr = Arc::new(Mutex::new(Attribute::new("attr1", 42u32)));
+        let attr = Attribute::new("attr1", 42u32);
         let mut node = Node::new("node1");
         node.add_attr(attr);
 
         let mut sub_node = Node::new("node2");
-        sub_node.add_attr(Arc::new(Mutex::new(Attribute::new("attr4", 99u32))));
+        sub_node.add_attr(Attribute::new("attr4", 99u32));
 
         node.add_sub_node(sub_node);
         println!("Node: {}", node.to_dts(0));


### PR DESCRIPTION
Replace the `add_attr()` parameter type of Arc<Mutex<Attribute>> with Attribute.

Signed-off-by: Michael Zhao <michael2012zhao@hotmail.com>