### PR TITLE
Documentation: Add Doc comments for Property

### DIFF
--- a/src/dtb_generator.rs
+++ b/src/dtb_generator.rs
@@ -212,10 +212,7 @@ mod tests {
     fn test_dtb_generate_0() {
         // Build a simple device tree
         let mut root = Node::new("/");
-        root.add_property(Property::new_strings(
-            "compatible",
-            vec![String::from("linux,dummy-virt")],
-        ));
+        root.add_property(Property::new_strs("compatible", vec!["linux,dummy-virt"]));
         let tree = Tree::new(vec![], root);
 
         // Generate the DTB
@@ -247,10 +244,7 @@ mod tests {
     fn test_dtb_generate_1() {
         // Build a simple device tree
         let mut root = Node::new("");
-        root.add_property(Property::new_strings(
-            "compatible",
-            vec![String::from("linux,dummy-virt")],
-        ));
+        root.add_property(Property::new_strs("compatible", vec!["linux,dummy-virt"]));
         root.add_property(Property::new_u32("#address-cells", 2u32));
         root.add_property(Property::new_u32("#size-cells", 2u32));
         root.add_property(Property::new_u32("interrupt-parent", 1u32));
@@ -324,10 +318,7 @@ mod tests {
     fn test_dtb_generate_2() {
         // Build a simple device tree
         let mut root = Node::new("");
-        root.add_property(Property::new_strings(
-            "compatible",
-            vec![String::from("linux,dummy-virt")],
-        ));
+        root.add_property(Property::new_strs("compatible", vec!["linux,dummy-virt"]));
         let mut reservations = vec![];
         reservations.push(Arc::new(Mutex::new(Reservation::new(0x0, 0x100000))));
         reservations.push(Arc::new(Mutex::new(Reservation::new(0x100000, 0x100000))));

--- a/src/dts_generator.rs
+++ b/src/dts_generator.rs
@@ -100,10 +100,8 @@ mod tests {
 
     #[test]
     fn test_dts_generate_property_strs() {
-        let string1 = String::from("hello");
-        let string2 = String::from("abc");
-        let strs = vec![string1, string2];
-        let prop = Property::new_strings("prop", strs);
+        let strs = vec!["hello", "abc"];
+        let prop = Property::new_strs("prop", strs);
         assert_eq!(
             DtsGenerator::generate_property(&prop, 0),
             "prop = <0x68 0x65 0x6c 0x6c 0x6f 0x0 0x61 0x62 0x63 0x0>;"
@@ -112,8 +110,7 @@ mod tests {
 
     #[test]
     fn test_dts_generate_property_str() {
-        let s = String::from("hello abc");
-        let prop = Property::new_string("prop", s);
+        let prop = Property::new_str("prop", "hello abc");
         assert_eq!(
             DtsGenerator::generate_property(&prop, 0),
             "prop = <0x68 0x65 0x6c 0x6c 0x6f 0x20 0x61 0x62 0x63 0x0>;"

--- a/src/property.rs
+++ b/src/property.rs
@@ -3,31 +3,105 @@
 
 use crate::dts_generator::DtsGenerator;
 
+/// A property that describes a characteristic of node.
+///
+/// # Examples
+///
+/// You can create an empty property with a name:
+///
+/// ```
+/// use devicetree_tool::property::Property;
+///
+/// let prop = Property::new_empty("prop");
+///
+/// assert_eq!(prop.value, vec![]);
+/// ```
+///
+/// Or create a property with value in the type of `u32`, `u64`, `str` or others.
+///
+/// ```
+/// use devicetree_tool::property::Property;
+///
+/// let prop = Property::new_u32("prop", 42);
+///
+/// assert_eq!(format!("{}", prop), "prop = <0x0 0x0 0x0 0x2a>;\n");
+/// ```
 pub struct Property {
     pub name: String,
     pub value: Vec<u8>,
 }
 
 impl Property {
+    /// Create a `Property` with a name, but without any value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_empty("prop");
+    ///
+    /// assert_eq!(prop.value, vec![]);
+    /// assert_eq!(format!("{}", prop), "prop;\n");
+    /// ```
     pub fn new_empty(name: &str) -> Self {
         Property {
             name: String::from(name),
             value: vec![],
         }
     }
+
+    /// Create a named `Property` with the value of type `u32`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_u32("prop", 42);
+    ///
+    /// assert_eq!(prop.value, vec![0u8, 0u8, 0u8, 42u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x0 0x0 0x0 0x2a>;\n");
+    /// ```
     pub fn new_u32(name: &str, value: u32) -> Self {
         Property {
             name: String::from(name),
             value: value.to_be_bytes().to_vec(),
         }
     }
+
+    /// Create a named `Property` with the value of type `u64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_u64("prop", 42);
+    ///
+    /// assert_eq!(prop.value, vec![0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 42u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x2a>;\n");
+    /// ```
     pub fn new_u64(name: &str, value: u64) -> Self {
         Property {
             name: String::from(name),
             value: value.to_be_bytes().to_vec(),
         }
     }
-    pub fn new_string(name: &str, value: String) -> Self {
+
+    /// Create a named `Property` with the value of string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_str("prop", "hello");
+    ///
+    /// assert_eq!(prop.value, vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x68 0x65 0x6c 0x6c 0x6f 0x0>;\n");
+    /// ```
+    pub fn new_str(name: &str, value: &str) -> Self {
         let mut bytes: Vec<u8> = value.as_bytes().to_vec();
         bytes.push(0);
         Property {
@@ -35,7 +109,20 @@ impl Property {
             value: bytes,
         }
     }
-    pub fn new_strings(name: &str, value: Vec<String>) -> Self {
+
+    /// Create a named `Property` with the value of a string list.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_strs("prop", vec!["hello", "abc"]);
+    ///
+    /// assert_eq!(prop.value, vec!['h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0u8, 'a' as u8, 'b' as u8, 'c' as u8, 0u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x68 0x65 0x6c 0x6c 0x6f 0x0 0x61 0x62 0x63 0x0>;\n");
+    /// ```
+    pub fn new_strs(name: &str, value: Vec<&str>) -> Self {
         let mut bytes: Vec<u8> = vec![];
         for v in value {
             let mut v_bytes = v.as_bytes().to_vec();
@@ -47,12 +134,38 @@ impl Property {
             value: bytes,
         }
     }
+
+    /// Create a named `Property` with the value of a `u8` array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_u8s("prop", vec![1u8, 2u8, 3u8, 4u8]);
+    ///
+    /// assert_eq!(prop.value, vec![1u8, 2u8, 3u8, 4u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x1 0x2 0x3 0x4>;\n");
+    /// ```
     pub fn new_u8s(name: &str, value: Vec<u8>) -> Self {
         Property {
             name: String::from(name),
             value,
         }
     }
+
+    /// Create a named `Property` with the value of a `u32` array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use devicetree_tool::property::Property;
+    ///
+    /// let prop = Property::new_u32s("prop", vec![1u32, 2u32]);
+    ///
+    /// assert_eq!(prop.value, vec![0u8, 0u8, 0u8, 1u8, 0u8, 0u8, 0u8, 2u8]);
+    /// assert_eq!(format!("{}", prop), "prop = <0x0 0x0 0x0 0x1 0x0 0x0 0x0 0x2>;\n");
+    /// ```
     pub fn new_u32s(name: &str, value: Vec<u32>) -> Self {
         let mut bytes: Vec<u8> = vec![];
         for v in value {
@@ -98,8 +211,7 @@ mod tests {
 
     #[test]
     fn test_property_str() {
-        let s = String::from("hello abc");
-        let prop = Property::new_string("name", s);
+        let prop = Property::new_str("name", "hello abc");
         assert_eq!(
             prop.value,
             vec![
@@ -111,10 +223,8 @@ mod tests {
 
     #[test]
     fn test_property_strs() {
-        let string1 = String::from("hello");
-        let string2 = String::from("abc");
-        let strs = vec![string1, string2];
-        let prop = Property::new_strings("name", strs);
+        let strs = vec!["hello", "abc"];
+        let prop = Property::new_strs("name", strs);
         assert_eq!(
             prop.value,
             vec![


### PR DESCRIPTION
Added documentation comments for `Property` struct. Changed APIs:
 * Property::new_string -> Property::new_str
 * Property::new_strings -> Property::new_strs
