### PR TITLE
fixup: remove runtime panics from the DTS parser

### DIFF
--- a/src/devicetree.rs
+++ b/src/devicetree.rs
@@ -108,7 +108,14 @@ impl DeviceTree {
 
     /// Create a `Tree` from DTS text byte array.
     pub fn from_dts_bytes(dts: &[u8]) -> Self {
-        DtsParser::from_bytes(&dts).parse()
+        // FIXME: make this function fallible, and bubble-up the error instead of silently failing
+        match DtsParser::from_bytes(&dts).parse() {
+            Ok(tree) => tree,
+            Err(err) => {
+                println!("Error parsing the DTS tree: {err}");
+                Self::new(vec![], Node::new(""))
+            }
+        }
     }
 
     /// Generate the DTS text of a `Tree`.


### PR DESCRIPTION
Removes calls to `unwrap` and explicit `panic` macro calls. This helps to avoid runtime panics in the library, and bubbles-up any errors that occur.

The top level `DeviceTree::from_dts_bytes` is left as an infallible function, and any errors are printed with a `println` call. Maybe we want to make this fallible as well?

These changes are isolated to the DTS parser, and do not fix panics in the DTB parser.